### PR TITLE
Suppress deprecation warning for User.withDefaultPasswordEncoder()

### DIFF
--- a/security/src/main/java/com/example/micrometer/SecurityConfiguration.java
+++ b/security/src/main/java/com/example/micrometer/SecurityConfiguration.java
@@ -52,6 +52,7 @@ public class SecurityConfiguration {
                 })).httpBasic(withDefaults()).formLogin(withDefaults()).build();
     }
 
+    @SuppressWarnings("deprecation")
     @Bean
     InMemoryUserDetailsManager userDetailsService() {
         return new InMemoryUserDetailsManager(


### PR DESCRIPTION
Using `User.withDefaultPasswordEncoder()` produces the following warning:

```
> Task :security:compileJava
/Users/user/IdeaProjects/micrometer-samples/security/src/main/java/com/example/micrometer/SecurityConfiguration.java:58: warning: [deprecation] withDefaultPasswordEncoder() in User has been deprecated
                User.withDefaultPasswordEncoder().username("user").password("password").roles("USER").build());
                    ^
1 warning
```

Based on the following deprecation Javadoc, it seems okay to simply suppress it here:

> Using this method is not considered safe for production, but is acceptable for demos and getting started. For production purposes, ensure the password is encoded externally. See the method Javadoc for additional details. There are no plans to remove this support. It is deprecated to indicate that this is considered insecure for production purposes.