### PR TITLE
Upgrade to io.spring.nohttp:nohttp-gradle 0.0.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         // TODO: this plugin brings in org.springframework:spring-core:3.1.3.RELEASE and org.springframework:spring-asm:3.1.3.RELEASE
         // Because of this, it fails Boot's mainClass lookup mechanism, we need to find a better way to guard license headers
         // classpath ('gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1')
-        classpath 'io.spring.nohttp:nohttp-gradle:0.0.10'
+        classpath 'io.spring.nohttp:nohttp-gradle:0.0.11'
         classpath 'io.spring.javaformat:spring-javaformat-gradle-plugin:0.0.35'
     }
 


### PR DESCRIPTION
This PR upgrades to `io.spring.nohttp:nohttp-gradle` 0.0.11.