### PR TITLE
Add H2 dependency to task subproject

### DIFF
--- a/task/build.gradle
+++ b/task/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 		implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 	}
 
+	runtimeOnly 'com.h2database:h2'
+
 	testImplementation project(':test-common')
 	testImplementation 'io.micrometer:micrometer-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
This PR adds H2 dependency to the `task` subproject as Spring Cloud Task depends on Spring Boot JDBC Starter which requires a database since 3.0.3.

The `SpringCloudTaskApplicationTests.should_record_metrics()` is failing for the reason now.

See https://github.com/spring-cloud/spring-cloud-task/releases/tag/v3.0.3