### PR TITLE
Replace deprecated ContextSnapshot.setThreadLocalsFrom()

### DIFF
--- a/circuitbreaker-reactive/src/main/java/com/example/micrometer/ReactiveCircuitBreakerApplication.java
+++ b/circuitbreaker-reactive/src/main/java/com/example/micrometer/ReactiveCircuitBreakerApplication.java
@@ -1,6 +1,7 @@
 package com.example.micrometer;
 
 import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ContextSnapshotFactory;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
@@ -47,6 +48,8 @@ class CircuitService {
 
     private final ObservationRegistry observationRegistry;
 
+    private final ContextSnapshotFactory contextSnapshotFactory = ContextSnapshotFactory.builder().build();
+
     CircuitService(ReactiveCircuitBreakerFactory factory, Tracer tracer, ObservationRegistry observationRegistry) {
         this.factory = factory;
         this.tracer = tracer;
@@ -74,7 +77,7 @@ class CircuitService {
     }
 
     private void scoped(ContextView contextView, Runnable runnable) {
-        try (ContextSnapshot.Scope scope = ContextSnapshot.setThreadLocalsFrom(contextView,
+        try (ContextSnapshot.Scope scope = this.contextSnapshotFactory.setThreadLocalsFrom(contextView,
                 ObservationThreadLocalAccessor.KEY)) {
             runnable.run();
         }

--- a/data-reactive/src/main/java/com/example/micrometer/ReactiveNestedTransactionService.java
+++ b/data-reactive/src/main/java/com/example/micrometer/ReactiveNestedTransactionService.java
@@ -1,6 +1,7 @@
 package com.example.micrometer;
 
 import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ContextSnapshotFactory;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import io.micrometer.tracing.Tracer;
@@ -23,6 +24,8 @@ public class ReactiveNestedTransactionService {
 
     private final ReactiveCustomerRepository repository;
 
+    private final ContextSnapshotFactory contextSnapshotFactory = ContextSnapshotFactory.builder().build();
+
     public ReactiveNestedTransactionService(Tracer tracer, ObservationRegistry observationRegistry,
             ReactiveCustomerRepository repository) {
         this.tracer = tracer;
@@ -33,7 +36,7 @@ public class ReactiveNestedTransactionService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Mono<Void> requiresNew() {
         return Mono.deferContextual(contextView -> {
-            try (ContextSnapshot.Scope scope = ContextSnapshot.setThreadLocalsFrom(contextView,
+            try (ContextSnapshot.Scope scope = this.contextSnapshotFactory.setThreadLocalsFrom(contextView,
                     ObservationThreadLocalAccessor.KEY)) {
                 log.info("<ACCEPTANCE_TEST> <TRACE:{}> Hello from consumer requires new",
                         tracer.currentSpan().context().traceId());

--- a/rsocket-client/src/main/java/com/example/micrometer/RsocketClient.java
+++ b/rsocket-client/src/main/java/com/example/micrometer/RsocketClient.java
@@ -1,6 +1,7 @@
 package com.example.micrometer;
 
 import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ContextSnapshotFactory;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
@@ -64,6 +65,8 @@ class RsocketService {
 
     private final ObservationRegistry observationRegistry;
 
+    private final ContextSnapshotFactory contextSnapshotFactory = ContextSnapshotFactory.builder().build();
+
     RsocketService(RSocketRequester rSocketRequester, Tracer tracer, ObservationRegistry observationRegistry) {
         this.rSocketRequester = rSocketRequester;
         this.tracer = tracer;
@@ -76,7 +79,7 @@ class RsocketService {
             // You could use the client Obseravtion directy, but we're trying to show how
             // you would interact with
             // setting thread locals from Reactor Context
-            try (ContextSnapshot.Scope scope = ContextSnapshot.setThreadLocalsFrom(contextView,
+            try (ContextSnapshot.Scope scope = this.contextSnapshotFactory.setThreadLocalsFrom(contextView,
                     ObservationThreadLocalAccessor.KEY)) {
                 log.info("<ACCEPTANCE_TEST> <TRACE:{}> Hello from producer",
                         this.tracer.currentSpan().context().traceId());

--- a/rsocket-server/src/main/java/com/example/micrometer/RsocketServerApplication.java
+++ b/rsocket-server/src/main/java/com/example/micrometer/RsocketServerApplication.java
@@ -1,6 +1,7 @@
 package com.example.micrometer;
 
 import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ContextSnapshotFactory;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import io.micrometer.tracing.Tracer;
 import org.slf4j.Logger;
@@ -27,6 +28,8 @@ class RSocketController {
 
     private final Tracer tracer;
 
+    private final ContextSnapshotFactory contextSnapshotFactory = ContextSnapshotFactory.builder().build();
+
     RSocketController(Tracer tracer) {
         this.tracer = tracer;
     }
@@ -34,7 +37,7 @@ class RSocketController {
     @MessageMapping("foo")
     public Mono<String> span() {
         return Mono.deferContextual(contextView -> {
-            try (ContextSnapshot.Scope scope = ContextSnapshot.setThreadLocalsFrom(contextView,
+            try (ContextSnapshot.Scope scope = this.contextSnapshotFactory.setThreadLocalsFrom(contextView,
                     ObservationThreadLocalAccessor.KEY)) {
                 String traceId = this.tracer.currentSpan().context().traceId();
                 log.info("<ACCEPTANCE_TEST> <TRACE:{}> Hello from consumer", traceId);

--- a/vault-webclient/src/main/java/com/example/micrometer/VaultWebClientApplication.java
+++ b/vault-webclient/src/main/java/com/example/micrometer/VaultWebClientApplication.java
@@ -1,6 +1,7 @@
 package com.example.micrometer;
 
 import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ContextSnapshotFactory;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
@@ -37,6 +38,8 @@ class Config {
 
     private static final Logger log = LoggerFactory.getLogger(Config.class);
 
+    private final ContextSnapshotFactory contextSnapshotFactory = ContextSnapshotFactory.builder().build();
+
     @Bean
     CommandLineRunner myCommandLineRunner(WebClientService webClientService) {
         return args -> {
@@ -54,7 +57,7 @@ class Config {
     @Bean
     WebClientCustomizer testWebClientCustomizer(Tracer tracer, ObservationRegistry observationRegistry) {
         return webClientBuilder -> webClientBuilder.filter((request, next) -> Mono.deferContextual(contextView -> {
-            try (ContextSnapshot.Scope scope = ContextSnapshot.setThreadLocalsFrom(contextView,
+            try (ContextSnapshot.Scope scope = this.contextSnapshotFactory.setThreadLocalsFrom(contextView,
                     ObservationThreadLocalAccessor.KEY)) {
                 log.info("<ACCEPTANCE_TEST> <TRACE:{}> Hello from producer", tracer.currentSpan().context().traceId());
             }

--- a/webflux/src/main/java/com/example/micrometer/WebFluxApplication.java
+++ b/webflux/src/main/java/com/example/micrometer/WebFluxApplication.java
@@ -1,6 +1,7 @@
 package com.example.micrometer;
 
 import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ContextSnapshotFactory;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import io.micrometer.tracing.Tracer;
 import org.slf4j.Logger;
@@ -27,6 +28,8 @@ class WebFluxController {
 
     private final Tracer tracer;
 
+    private final ContextSnapshotFactory contextSnapshotFactory = ContextSnapshotFactory.builder().build();
+
     WebFluxController(Tracer tracer) {
         this.tracer = tracer;
     }
@@ -34,7 +37,7 @@ class WebFluxController {
     @RequestMapping("/")
     public Mono<String> span() {
         return Mono.deferContextual(contextView -> {
-            try (ContextSnapshot.Scope scope = ContextSnapshot.setThreadLocalsFrom(contextView,
+            try (ContextSnapshot.Scope scope = this.contextSnapshotFactory.setThreadLocalsFrom(contextView,
                     ObservationThreadLocalAccessor.KEY)) {
                 String traceId = this.tracer.currentSpan().context().traceId();
                 log.info("<ACCEPTANCE_TEST> <TRACE:{}> Hello from producer", traceId);


### PR DESCRIPTION
This PR replaces deprecated `ContextSnapshot.setThreadLocalsFrom()` usages.